### PR TITLE
Add travis build and admin password

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+notifications:
+  email: false
+language: minimal
+install: pip install --user awscli
+script: make dist
+jobs:
+  include:
+    - stage: deploy
+      before_deploy: make dist
+      deploy:
+        provider: script
+        script: make publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV GEOSERVER_VERSION_MM 2.14
 ENV GEOSERVER_HOME /usr/local/geoserver
 ENV GEOSERVER_DATA_DIR /var/geoserver/data
 
+RUN apt-get update && apt-get install -y gettext
 RUN mkdir -p ${GEOSERVER_HOME}
 RUN mkdir -p /var/geoserver
 
@@ -18,7 +19,13 @@ RUN cd /tmp && \
     curl -OL https://build.geoserver.org/geoserver/${GEOSERVER_VERSION_MM}.x/community-latest/geoserver-${GEOSERVER_VERSION_MM}-SNAPSHOT-s3-geotiff-plugin.zip && \
     unzip -o -d ${GEOSERVER_HOME}/webapps/geoserver/WEB-INF/lib/ geoserver-${GEOSERVER_VERSION_MM}-SNAPSHOT-s3-geotiff-plugin.zip
 
+COPY data ${GEOSERVER_DATA_DIR}
+COPY entrypoint.sh /usr/local/bin/
+
 VOLUME ["${GEOSERVER_DATA_DIR}"]
 
+ENV GEOSERVER_PASSWORD geoserver
+
 EXPOSE 8080
+ENTRYPOINT ["entrypoint.sh"]
 CMD ["sh", "-c", "${GEOSERVER_HOME}/bin/startup.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: help dist publish promote
+SHELL=/bin/bash
+ECR_REGISTRY=672626379771.dkr.ecr.us-east-1.amazonaws.com
+DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
+
+help: ## Print this message
+	@awk 'BEGIN { FS = ":.*##"; print "Usage:  make <target>\n\nTargets:" } \
+		/^[-_[:alpha:]]+:.?*##/ { printf "  %-15s%s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+dist: ## Build docker image
+	docker build -t $(ECR_REGISTRY)/geoserver-stage:latest \
+		-t $(ECR_REGISTRY)/geoserver-stage:`git describe --always` \
+		-t geoserver .
+
+publish: ## Push and tag the latest image (use `make dist && make publish`)
+	$$(aws ecr get-login --no-include-email --region us-east-1)
+	docker push $(ECR_REGISTRY)/geoserver-stage:latest
+	docker push $(ECR_REGISTRY)/geoserver-stage:`git describe --always`
+
+promote: ## Promote the current staging build to production
+	$$(aws ecr get-login --no-include-email --region us-east-1)
+	docker pull $(ECR_REGISTRY)/geoserver-stage:latest
+	docker tag $(ECR_REGISTRY)/geoserver-stage:latest $(ECR_REGISTRY)/geoserver-prod:latest
+	docker tag $(ECR_REGISTRY)/geoserver-stage:latest $(ECR_REGISTRY)/geoserver-prod:$(DATETIME)
+	docker push $(ECR_REGISTRY)/geoserver-prod:latest
+	docker push $(ECR_REGISTRY)/geoserver-prod:$(DATETIME)

--- a/data/security/usergroup/default/config.xml
+++ b/data/security/usergroup/default/config.xml
@@ -1,0 +1,10 @@
+<userGroupService>
+  <id>52857278:13c7ffd66a8:-7ffd</id>
+  <name>default</name>
+  <className>org.geoserver.security.xml.XMLUserGroupService</className>
+  <fileName>users.xml</fileName>
+  <checkInterval>10000</checkInterval>
+  <validating>true</validating>
+  <passwordEncoderName>plainTextPasswordEncoder</passwordEncoderName>
+  <passwordPolicyName>default</passwordPolicyName>
+</userGroupService>

--- a/data/security/usergroup/default/users.xml.tmpl
+++ b/data/security/usergroup/default/users.xml.tmpl
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<userRegistry version="1.0" xmlns="http://www.geoserver.org/security/users">
+  <users>
+    <user enabled="true" name="admin" password="plain:${GEOSERVER_PASSWORD}"/>
+  </users>
+  <groups/>
+</userRegistry>

--- a/data/workspaces/default.xml
+++ b/data/workspaces/default.xml
@@ -1,0 +1,5 @@
+<workspace>
+  <id>WorkspaceInfoImpl--2fcf176d:169357d9a44:-7fff</id>
+  <name>mit</name>
+  <isolated>false</isolated>
+</workspace>

--- a/data/workspaces/mit/namespace.xml
+++ b/data/workspaces/mit/namespace.xml
@@ -1,0 +1,6 @@
+<namespace>
+  <id>NamespaceInfoImpl--2fcf176d:169357d9a44:-7ffe</id>
+  <prefix>mit</prefix>
+  <uri>http://geodata.mit.edu</uri>
+  <isolated>false</isolated>
+</namespace>

--- a/data/workspaces/mit/workspace.xml
+++ b/data/workspaces/mit/workspace.xml
@@ -1,0 +1,5 @@
+<workspace>
+  <id>WorkspaceInfoImpl--2fcf176d:169357d9a44:-7fff</id>
+  <name>mit</name>
+  <isolated>false</isolated>
+</workspace>

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+USERS=$GEOSERVER_DATA_DIR/security/usergroup/default/users.xml
+
+envsubst < $USERS.tmpl > $USERS
+
+exec "$@"


### PR DESCRIPTION
This sets up the automated travis build which will push the image to the
staging repo when merging into master. In addition, this adds a default
workspace named `mit` and configures the container to pull the admin
password from the `GEOSERVER_PASSWORD` environment variable.