### PR TITLE
Add support for minio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,12 @@ COPY entrypoint.sh /usr/local/bin/
 
 VOLUME ["${GEOSERVER_DATA_DIR}"]
 
+ENV GEOSERVER_USER admin
 ENV GEOSERVER_PASSWORD geoserver
+ENV MINIO_URL http://minio:9000/
+ENV MINIO_ALIAS minio
+ENV MINIO_USER minio
+ENV MINIO_PASSWORD miniopass
 
 EXPOSE 8080
 ENTRYPOINT ["entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,29 @@
 
-GeoServer
-=========
+# MIT Libraries GeoServer
 
-Start with persistent storage:
+This container is used as the GeoServer instance for [GeoWeb](https://github.com/MITLibraries/geoweb). It adds support for the S3 GeoTiff community plugin.
 
-    $ docker run --name geo-data -d mitlibraries/geoserver /bin/true
-    $ docker run --name geoserver -d --volumes-from geo-data mitlibraries/geoserver
+## Running the Container
+
+Start the container with:
+
+    $ docker run -p 8080:8080 mitlibraries/geoserver
+
+By default the username is `admin` and the password is `geoserver`, but both of these can be set at runtime by using environment variables:
+
+    $ docker run -e GEOSERVER_USER=myuser -e GEOSERVER_PASSWORD=mypassword -p 8080:8080 mitlibraries/geoserver
+
+## Using with Minio
+
+This container supports serving GeoTiffs from S3. You can also use [Minio](https://github.com/minio/minio) as a drop-in replacement for (or in addition) to S3. There are four environment variables used to configure Minio support that can be set at runtime:
+
+envvar | default value | description
+--- | --- | ---
+`MINIO_URL` | `http://minio:9000/` | URL for the Minio server
+`MINIO_ALIAS` | `minio` | This is used when adding an S3 GeoTiff coverage store as the protocol, for example `minio://mybucket/someraster.tiff`
+`MINIO_USER` | `minio` | username
+`MINIO_PASSWORD` | `miniopass` | password
+
+In order to enable Minio support the GeoServer container needs to be configured to use the S3 settings:
+
+    $ docker run -e JAVA_OPTS="-Ds3.properties.location=/var/geoserver/data/s3.properties" -p 8080:8080 mitlibraries/geoserver

--- a/data/s3.properties.tmpl
+++ b/data/s3.properties.tmpl
@@ -1,0 +1,3 @@
+${MINIO_ALIAS}.s3.endpoint=${MINIO_URL}
+${MINIO_ALIAS}.s3.user=${MINIO_USER}
+${MINIO_ALIAS}.s3.password=${MINIO_PASSWORD}

--- a/data/security/usergroup/default/users.xml.tmpl
+++ b/data/security/usergroup/default/users.xml.tmpl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <userRegistry version="1.0" xmlns="http://www.geoserver.org/security/users">
   <users>
-    <user enabled="true" name="admin" password="plain:${GEOSERVER_PASSWORD}"/>
+    <user enabled="true" name="${GEOSERVER_USER}" password="plain:${GEOSERVER_PASSWORD}"/>
   </users>
   <groups/>
 </userRegistry>

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 USERS=$GEOSERVER_DATA_DIR/security/usergroup/default/users.xml
+S3_PROPERTIES=$GEOSERVER_DATA_DIR/s3.properties
 
 envsubst < $USERS.tmpl > $USERS
+envsubst < $S3_PROPERTIES.tmpl > $S3_PROPERTIES
 
 exec "$@"


### PR DESCRIPTION
This adds support for running minio as an S3 alternative. Three new
environment variables for runtime configuration of the minio server have
been added.