### PR TITLE
Configure GeoWebCache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN rm -rf ${GEOSERVER_DATA_DIR}/coverages/* \
            ${GEOSERVER_DATA_DIR}/data/* \
            ${GEOSERVER_DATA_DIR}/demo \
            ${GEOSERVER_DATA_DIR}/layergroups/* \
-           ${GEOSERVER_DATA_DIR}/workspaces \
+           ${GEOSERVER_DATA_DIR}/workspaces/* \
            ${GEOSERVER_DATA_DIR}/www
 COPY data ${GEOSERVER_DATA_DIR}
 COPY entrypoint.sh /usr/local/bin/

--- a/data/gwc-gs.xml
+++ b/data/gwc-gs.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<GeoServerGWCConfig>
+  <version>1.1.0</version>
+  <directWMSIntegrationEnabled>true</directWMSIntegrationEnabled>
+  <WMSCEnabled>false</WMSCEnabled>
+  <TMSEnabled>false</TMSEnabled>
+  <securityEnabled>true</securityEnabled>
+  <innerCachingEnabled>false</innerCachingEnabled>
+  <cacheLayersByDefault>true</cacheLayersByDefault>
+  <cacheNonDefaultStyles>true</cacheNonDefaultStyles>
+  <metaTilingX>4</metaTilingX>
+  <metaTilingY>4</metaTilingY>
+  <gutter>0</gutter>
+  <defaultCachingGridSetIds>
+    <string>EPSG:900913</string>
+  </defaultCachingGridSetIds>
+  <defaultCoverageCacheFormats>
+    <string>image/png</string>
+    <string>image/jpeg</string>
+  </defaultCoverageCacheFormats>
+  <defaultVectorCacheFormats>
+    <string>image/png</string>
+    <string>image/jpeg</string>
+  </defaultVectorCacheFormats>
+  <defaultOtherCacheFormats>
+    <string>image/png</string>
+    <string>image/jpeg</string>
+  </defaultOtherCacheFormats>
+</GeoServerGWCConfig>

--- a/data/gwc/geowebcache-diskquota.xml
+++ b/data/gwc/geowebcache-diskquota.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<gwcQuotaConfiguration>
+  <enabled>true</enabled>
+  <cacheCleanUpFrequency>10</cacheCleanUpFrequency>
+  <cacheCleanUpUnits>SECONDS</cacheCleanUpUnits>
+  <maxConcurrentCleanUps>2</maxConcurrentCleanUps>
+  <globalExpirationPolicyName>LFU</globalExpirationPolicyName>
+  <globalQuota>
+    <value>500</value>
+    <units>MiB</units>
+  </globalQuota>
+  <quotaStore>H2</quotaStore>
+</gwcQuotaConfiguration>

--- a/data/workspaces/default.xml
+++ b/data/workspaces/default.xml
@@ -1,5 +1,0 @@
-<workspace>
-  <id>WorkspaceInfoImpl--2fcf176d:169357d9a44:-7fff</id>
-  <name>mit</name>
-  <isolated>false</isolated>
-</workspace>

--- a/data/workspaces/mit/namespace.xml
+++ b/data/workspaces/mit/namespace.xml
@@ -1,6 +1,0 @@
-<namespace>
-  <id>NamespaceInfoImpl--2fcf176d:169357d9a44:-7ffe</id>
-  <prefix>mit</prefix>
-  <uri>http://geodata.mit.edu</uri>
-  <isolated>false</isolated>
-</namespace>

--- a/data/workspaces/mit/workspace.xml
+++ b/data/workspaces/mit/workspace.xml
@@ -1,5 +1,0 @@
-<workspace>
-  <id>WorkspaceInfoImpl--2fcf176d:169357d9a44:-7fff</id>
-  <name>mit</name>
-  <isolated>false</isolated>
-</workspace>


### PR DESCRIPTION
This removes the mit workspace as these are being managed through the
REST API. The main update here configures the GeoWebCache. This can't be
configured through the REST API so it needs to be manually configured
during the container build.