### PR TITLE
Refactor Dockerfile to support bind mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir -p ${GEOSERVER_DATA_DIR}
 FROM base AS build
 
 RUN apk add --no-cache curl
-RUN curl -OL http://sourceforge.net/projects/geoserver/files/GeoServer/${GEOSERVER_VERSION}/geoserver-${GEOSERVER_VERSION}-bin.zip && \
+RUN curl -OL https://sourceforge.net/projects/geoserver/files/GeoServer/${GEOSERVER_VERSION}/geoserver-${GEOSERVER_VERSION}-bin.zip && \
     unzip geoserver-${GEOSERVER_VERSION}-bin.zip
 RUN curl -OL https://build.geoserver.org/geoserver/${GEOSERVER_VERSION_MM}.x/community-latest/geoserver-${GEOSERVER_VERSION_MM}-SNAPSHOT-s3-geotiff-plugin.zip && \
     unzip -o -d ${GEOSERVER_HOME}/webapps/geoserver/WEB-INF/lib/ geoserver-${GEOSERVER_VERSION_MM}-SNAPSHOT-s3-geotiff-plugin.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,34 @@
-FROM openjdk:8
+# Base image used for both building and running
+FROM openjdk:8-jre-alpine AS base
 
 ENV GEOSERVER_VERSION 2.14.3
 ENV GEOSERVER_VERSION_MM 2.14
-ENV GEOSERVER_HOME /usr/local/geoserver
+ENV GEOSERVER_HOME /geoserver-${GEOSERVER_VERSION}
 ENV GEOSERVER_DATA_DIR /var/geoserver/data
 
-RUN apt-get update && apt-get install -y gettext
 RUN mkdir -p ${GEOSERVER_HOME}
-RUN mkdir -p /var/geoserver
+RUN mkdir -p ${GEOSERVER_DATA_DIR}
 
-RUN cd /tmp && \
-    curl -L -O http://sourceforge.net/projects/geoserver/files/GeoServer/${GEOSERVER_VERSION}/geoserver-${GEOSERVER_VERSION}-bin.zip && \
-    unzip geoserver-${GEOSERVER_VERSION}-bin.zip && \
-    mv geoserver-${GEOSERVER_VERSION}/* ${GEOSERVER_HOME}
 
-RUN mv ${GEOSERVER_HOME}/data_dir ${GEOSERVER_DATA_DIR}
-RUN cd /tmp && \
-    curl -OL https://build.geoserver.org/geoserver/${GEOSERVER_VERSION_MM}.x/community-latest/geoserver-${GEOSERVER_VERSION_MM}-SNAPSHOT-s3-geotiff-plugin.zip && \
+# Build image
+FROM base AS build
+
+RUN apk add --no-cache curl
+RUN curl -OL http://sourceforge.net/projects/geoserver/files/GeoServer/${GEOSERVER_VERSION}/geoserver-${GEOSERVER_VERSION}-bin.zip && \
+    unzip geoserver-${GEOSERVER_VERSION}-bin.zip
+RUN curl -OL https://build.geoserver.org/geoserver/${GEOSERVER_VERSION_MM}.x/community-latest/geoserver-${GEOSERVER_VERSION_MM}-SNAPSHOT-s3-geotiff-plugin.zip && \
     unzip -o -d ${GEOSERVER_HOME}/webapps/geoserver/WEB-INF/lib/ geoserver-${GEOSERVER_VERSION_MM}-SNAPSHOT-s3-geotiff-plugin.zip
+RUN cd ${GEOSERVER_HOME}/data_dir/ && \
+    rm -rf coverages/* data/* demo layergroups/* workspaces www
+COPY data ${GEOSERVER_HOME}/data_dir/
 
-RUN rm -rf ${GEOSERVER_DATA_DIR}/coverages/* \
-           ${GEOSERVER_DATA_DIR}/data/* \
-           ${GEOSERVER_DATA_DIR}/demo \
-           ${GEOSERVER_DATA_DIR}/layergroups/* \
-           ${GEOSERVER_DATA_DIR}/workspaces/* \
-           ${GEOSERVER_DATA_DIR}/www
-COPY data ${GEOSERVER_DATA_DIR}
+
+# Run image
+FROM base
+
+RUN apk add --no-cache gettext ttf-dejavu
+COPY --from=build ${GEOSERVER_HOME} ${GEOSERVER_HOME}
 COPY entrypoint.sh /usr/local/bin/
-
-VOLUME ["${GEOSERVER_DATA_DIR}"]
 
 ENV GEOSERVER_USER admin
 ENV GEOSERVER_PASSWORD geoserver
@@ -37,6 +37,7 @@ ENV MINIO_ALIAS minio
 ENV MINIO_USER minio
 ENV MINIO_PASSWORD miniopass
 
+VOLUME ["${GEOSERVER_DATA_DIR}"]
 EXPOSE 8080
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["sh", "-c", "${GEOSERVER_HOME}/bin/startup.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,9 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 USERS=$GEOSERVER_DATA_DIR/security/usergroup/default/users.xml
 S3_PROPERTIES=$GEOSERVER_DATA_DIR/s3.properties
 
+cp -rf $GEOSERVER_HOME/data_dir/* $GEOSERVER_DATA_DIR
 envsubst < $USERS.tmpl > $USERS
 envsubst < $S3_PROPERTIES.tmpl > $S3_PROPERTIES
 


### PR DESCRIPTION
The ECS deploy will need to use a bind mount for the GeoServer data
directory. Rather than managing the contents of the data directory
during build time, these changes will now copy the data directory
contents from the build image to the volume at run time.

This also optimizes the Dockerfile to use multistage builds and switches
to alpine. The resulting container is about 650MB smaller.