### PR TITLE
Switch travis distro to use recent python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-notifications:
-  email: false
-language: minimal
-install: pip install --user awscli
+dist: xenial
+language: python
+python: 3.7
+install: pip install awscli
 script: make dist
 jobs:
   include:


### PR DESCRIPTION
The python version on a stock travis build is too old. The AWS ECR
commands were failing.